### PR TITLE
Fix in wrapper

### DIFF
--- a/R/GlobalFunctions.R
+++ b/R/GlobalFunctions.R
@@ -1772,25 +1772,32 @@ listDatasets <- function( dataset )
 #'}
 
 
-
 chicWrapper<-function(chipName, inputName, read_length, 
     savePlotPath=NULL, target, annotationID="hg19", 
     mc=1, debug=FALSE)
 {
 
-    if (is.null(savePlotPath) || !(dir.exists(savePlotPath)))
-    ## { 
-    ##     stop("Please provide a path to save the summary 
-    ##         plot (String required)")
-    ## }else{
+    if (!is.null(savePlotPath))
     {
+        tryCatch(
+        {
+            pdf(savePlotPath,onefile=TRUE)
+        },
+        error = function(e){
+            message("Creating an overall pdf report in 
+                    the working directory (ChIC_report.pdf)")
+            savePlotPath <- paste(getwd(),"ChIC_report.pdf",sep="/")
+            pdf(savePlotPath,onefile=TRUE)
+        }
+        )
+    }else{
         message("Creating an overall pdf report in 
-            the working directory (ChIC_report.pdf)")
-        report_file <- paste(getwd(),"ChIC_report.pdf",sep="/")        
+                    the working directory (ChIC_report.pdf)")
+        savePlotPath <- paste(getwd(),"ChIC_report.pdf",sep="/")
+        pdf(savePlotPath,onefile=TRUE)
     }
 
-    pdf(report_file,onefile=TRUE)
-    # get Encode Metrics
+    ## get Encode Metrics
     CC_Result=qualityScores_EM(
         chipName=chipName,
         inputName=inputName,
@@ -1887,9 +1894,9 @@ chicWrapper<-function(chipName, inputName, read_length,
     }
 
     if(target %in% listAvailableElements("mark") || target %in% listAvailableElements("TF") || target == "TF")
-
-    { message("Calculating the prediction score...")
-
+    {
+        message("Calculating the prediction score...")
+        
         predictedScore=predictionScore(
             target=target,
             features_cc=CC_Result,
@@ -1898,15 +1905,17 @@ chicWrapper<-function(chipName, inputName, read_length,
             features_TES=TESProfile,
             features_scaled=geneBody_Plot
         )
+
         print("prediction")
         print(predictedScore)
+
     } else {
         stop( "Histone mark or TF not found. 
             Could not calculate the prediction score 
             using chicWrapper(). You might try the 
             predictionScore() function wihtout the wrapper." )
     }
-
+    
     dev.off()
     return(predictedScore)
 }

--- a/R/GlobalFunctions.R
+++ b/R/GlobalFunctions.R
@@ -1805,7 +1805,7 @@ chicWrapper<-function(chipName, inputName, read_length,
         debug=debug,
         mc=mc,
         annotationID=annotationID,
-        savePlotPath=savePlotPath
+        savePlotPath=NULL
     )
     
     ##save the tagshift as it is needed later
@@ -1821,7 +1821,7 @@ chicWrapper<-function(chipName, inputName, read_length,
     Ch_Results=qualityScores_GM(
         densityChip=smoothedDensityChip,
         densityInput=smoothedDensityInput,
-        savePlotPath=savePlotPath,
+        savePlotPath=NULL,
         debug=debug
     )
     
@@ -1841,20 +1841,20 @@ chicWrapper<-function(chipName, inputName, read_length,
     TSSProfile=qualityScores_LM(
         Meta_Result$TSS,
         tag="TSS",
-        savePlotPath=savePlotPath,
+        savePlotPath=NULL,
         debug=debug
     )
     
     TESProfile=qualityScores_LM(
         Meta_Result$TES,
         tag="TES",
-        savePlotPath=savePlotPath,
+        savePlotPath=NULL,
         debug=debug
     )
     
     geneBody_Plot=qualityScores_LMgenebody(
         Meta_Result$geneBody,
-        savePlotPath=savePlotPath,
+        savePlotPath=NULL,
         debug=debug
     )
 
@@ -1866,28 +1866,28 @@ chicWrapper<-function(chipName, inputName, read_length,
             target=target,
             data=Meta_Result$geneBody,
             tag="geneBody",
-            savePlotPath=savePlotPath
+            savePlotPath=NULL
         )
         
         metagenePlotsForComparison(
             target=target,
             Meta_Result$TSS,
             tag="TSS",
-            savePlotPath=savePlotPath
+            savePlotPath=NULL
         )
         
         metagenePlotsForComparison(
             target=target,
             Meta_Result$TES,
             tag="TES",
-            savePlotPath=savePlotPath
+            savePlotPath=NULL
         )
         
         plotReferenceDistribution(
             target=target,
             metricToBePlotted="RSC",
             currentValue=CC_Result$QCscores_ChIP$CC_RSC,
-            savePlotPath=savePlotPath
+            savePlotPath=NULL
         )
     }else{
         message("The production of comparison plots is not supported for the \"TF\" target.")

--- a/R/GlobalFunctions.R
+++ b/R/GlobalFunctions.R
@@ -1779,17 +1779,17 @@ chicWrapper<-function(chipName, inputName, read_length,
 {
 
     if (is.null(savePlotPath) || !(dir.exists(savePlotPath)))
-    { 
-        stop("Please provide a path to save the summary 
-            plot (String required)")
-    }else{
-
+    ## { 
+    ##     stop("Please provide a path to save the summary 
+    ##         plot (String required)")
+    ## }else{
+    {
         message("Creating an overall pdf report in 
             the working directory (ChIC_report.pdf)")
         report_file <- paste(getwd(),"ChIC_report.pdf",sep="/")        
-        pdf(report_file,onefile=TRUE)
     }
-    
+
+    pdf(report_file,onefile=TRUE)
     # get Encode Metrics
     CC_Result=qualityScores_EM(
         chipName=chipName,
@@ -1886,24 +1886,12 @@ chicWrapper<-function(chipName, inputName, read_length,
         message("The production of comparison plots is not supported for the \"TF\" target.")
     }
 
-    if ( target %in% f_metaGeneDefinition("Hlist") ) { 
-        message( "Chromatin mark available for 
-        prediction..." )
+    if(target %in% listAvailableElements("mark") || target %in% listAvailableElements("TF") || target == "TF")
+
+    { message("Calculating the prediction score...")
 
         predictedScore=predictionScore(
             target=target,
-            features_cc=CC_Result,
-            features_global=Ch_Results,
-            features_TSS=TSSProfile,
-            features_TES=TESProfile,
-            features_scaled=geneBody_Plot
-        )
-        print("prediction")
-        print(predictedScore)
-
-    } else if ( target %in% f_metaGeneDefinition( "TFlist" )) { 
-            predictedScore=predictionScore(
-            target="TF",
             features_cc=CC_Result,
             features_global=Ch_Results,
             features_TSS=TSSProfile,

--- a/R/GlobalFunctions.R
+++ b/R/GlobalFunctions.R
@@ -1851,35 +1851,40 @@ chicWrapper<-function(chipName, inputName, read_length,
         debug=debug
     )
 
-    ##additional plots
 
-    metagenePlotsForComparison(
-        target=target,
-        data=Meta_Result$geneBody,
-        tag="geneBody",
-        savePlotPath=savePlotPath
-    )
-    
-    metagenePlotsForComparison(
-        target=target,
-        Meta_Result$TSS,
-        tag="TSS",
-        savePlotPath=savePlotPath
-    )
-    
-    metagenePlotsForComparison(
-        target=target,
-        Meta_Result$TES,
-        tag="TES",
-        savePlotPath=savePlotPath
-    )
-    
-    plotReferenceDistribution(
-        target=target,
-        metricToBePlotted="RSC",
-        currentValue=CC_Result$QCscores_ChIP$CC_RSC,
-        savePlotPath=savePlotPath
-    )
+    if(target != "TF"){
+        ##additional plots
+        
+        metagenePlotsForComparison(
+            target=target,
+            data=Meta_Result$geneBody,
+            tag="geneBody",
+            savePlotPath=savePlotPath
+        )
+        
+        metagenePlotsForComparison(
+            target=target,
+            Meta_Result$TSS,
+            tag="TSS",
+            savePlotPath=savePlotPath
+        )
+        
+        metagenePlotsForComparison(
+            target=target,
+            Meta_Result$TES,
+            tag="TES",
+            savePlotPath=savePlotPath
+        )
+        
+        plotReferenceDistribution(
+            target=target,
+            metricToBePlotted="RSC",
+            currentValue=CC_Result$QCscores_ChIP$CC_RSC,
+            savePlotPath=savePlotPath
+        )
+    }else{
+        message("The production of comparison plots is not supported for the \"TF\" target.")
+    }
 
     if ( target %in% f_metaGeneDefinition("Hlist") ) { 
         message( "Chromatin mark available for 


### PR DESCRIPTION
1. When the target is specified with the "TF" keyword, no "metagene" plots are produced.

2. Fixed little bug for pdf creation: once again all plots are stored in a unique pdf. 